### PR TITLE
Tile factory thread safety.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ target/
 # Gradle
 build/
 .gradle/
+
+# IntelliJ
+.idea/
+*.iml

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/AbstractTileFactory.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/AbstractTileFactory.java
@@ -157,7 +157,7 @@ public abstract class AbstractTileFactory extends TileFactory
 	/**
 	 * Thread pool for loading the tiles
 	 */
-	private static BlockingQueue<Tile> tileQueue = new PriorityBlockingQueue<Tile>(5, new Comparator<Tile>()
+	private BlockingQueue<Tile> tileQueue = new PriorityBlockingQueue<Tile>(5, new Comparator<Tile>()
 	{
 		@Override
 		public int compare(Tile o1, Tile o2)


### PR DESCRIPTION
AbstractTileFactory (and thus DefaultTileFactory) was not thread safe. If for example multiple instances of JXMapViewer were created with different *TileFactories it was almost always the case, that there was some thread racing in AbstractTileFactory:314 
```final Tile tile = tileQueue.remove();```

One *TileFactory instance was creating an executorService (with default 4 threads) for tile tasks. However the tileQueue was static -> thus shared among multiple instances of *TileFactory (if existed). 