### PR TITLE
Fix cursor being changed on main map of JXMapKit

### DIFF
--- a/jxmapviewer2/src/main/java/org/jxmapviewer/input/PanMouseInputListener.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/input/PanMouseInputListener.java
@@ -31,6 +31,9 @@ public class PanMouseInputListener extends MouseInputAdapter
 	@Override
 	public void mousePressed(MouseEvent evt)
 	{
+		if (!SwingUtilities.isLeftMouseButton(evt))
+			return;
+
 		prev = evt.getPoint();
 		priorCursor = viewer.getCursor();
 		viewer.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));


### PR DESCRIPTION
When using an instance of JXMapKit, right-clicking or middle-clicking on the main map results in the cursor being changed to a drag icon. The cursor will stay this way on the main map. With this fix, right-clicking or middle-clicking has no effect.