### PR TITLE
Make User-Agent configurable

### DIFF
--- a/jxmapviewer2/build.gradle
+++ b/jxmapviewer2/build.gradle
@@ -79,6 +79,13 @@ uploadArchives {
     }
 }
 
+processResources {
+    filesMatching('project.properties') {
+        expand projectVersion: project.version,
+               projectName: project.name
+    }
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = '1.12'
 }

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/util/ProjectProperties.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/util/ProjectProperties.java
@@ -1,0 +1,78 @@
+package org.jxmapviewer.util;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * Project properties.
+ *
+ * @author Primoz K.
+ */
+public class ProjectProperties {
+
+	private static final Log log = LogFactory.getLog(ProjectProperties.class);
+
+	private static Properties props = new Properties();
+
+	private static final String PROPERTIES_FILE = "project.properties";
+
+	/***************************************************************
+	 ************************* PROPERTIES **************************
+	 ***************************************************************/
+
+	private static final String PROP_VERSION = "version";
+	private static final String PROP_NAME = "name";
+
+	/***************************************************************
+	 *********************** INITIALIZATION ************************
+	 ***************************************************************/
+
+	static {
+		log.debug("Loading project properties...");
+
+		InputStream is = null;
+		try {
+			ClassLoader classloader = Thread.currentThread().getContextClassLoader();
+			is = classloader.getResourceAsStream(PROPERTIES_FILE);
+			props.load(is);
+			log.debug("Properties successfully loaded.");
+
+		}
+		catch (IOException e) {
+			throw new RuntimeException("Unable to read project properties." + e);
+		}
+		finally {
+			try {
+				if (is != null) {
+					is.close();
+				}
+			}
+			catch (IOException e) {
+				log.warn("Unable to close stream.", e);
+			}
+		}
+	}
+
+	/***************************************************************
+	 ********************* PROPERTIES GETTERS **********************
+	 ***************************************************************/
+
+	/**
+	 * @return Project version.
+	 */
+	public static String getVersion() {
+		return props.getProperty(PROP_VERSION);
+	}
+
+	/**
+	 * @return Project name.
+	 */
+	public static String getName() {
+		return props.getProperty(PROP_NAME);
+	}
+
+}

--- a/jxmapviewer2/src/main/resources/project.properties
+++ b/jxmapviewer2/src/main/resources/project.properties
@@ -1,0 +1,4 @@
+# Those two properties are used to set default User agent
+# Populated by Gradle (see processResources section of build.gradle)
+name=${projectName}
+version=${projectVersion}


### PR DESCRIPTION
Hi everyone,

This PR is in some way related to already closed issue #13.

The thing is that right now _all applications that make use of JXMapViewer2_ library uses the same User-Agent _JxMapViewer/1.0_ which doesn't comply with OSM tiles server usage policy which say that a valid User-Agent identifying application should be set.

Using this fix the _default_ User-Agent is set based on Gradle project's name and version properties (_i.e. JXMapViewer2/2.2-SNAPSHOT_) so there is no need to bump version number manually on each release.

In addition to that it is possible to to set custom User-Agent in order to properly identify application that is making use of JXMapViewer2 library under the hood.

Please let me know whether this PR is feasible and whether any further changes are needed.

Thank you.