### PR TITLE
Made horizontal infinite map rendering optional.

### DIFF
--- a/jxmapviewer2/src/main/java/org/jxmapviewer/JXMapViewer.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/JXMapViewer.java
@@ -107,6 +107,7 @@ public class JXMapViewer extends JPanel implements DesignMode
 
 	private boolean restrictOutsidePanning = true;
 	private boolean horizontalWrapped = true;
+	private boolean infiniteMapRendering = true;
 
 	/**
 	 * Create a new JXMapViewer. By default it will use the EmptyTileFactory
@@ -297,7 +298,8 @@ public class JXMapViewer extends JPanel implements DesignMode
 
 	private boolean isTileOnMap(int x, int y, Dimension mapSize)
 	{
-		return y >= 0 && y < mapSize.getHeight();
+		return (y >= 0 && y < mapSize.getHeight()) &&
+				  (isInfiniteMapRendering() || x >= 0 && x < mapSize.getWidth());
 	}
 
 	/**
@@ -798,6 +800,24 @@ public class JXMapViewer extends JPanel implements DesignMode
 	public boolean isHorizontalWrapped()
 	{
 		return horizontalWrapped;
+	}
+
+	/**
+	 * Side note: This setting is ignored when  horizontaklWrapped is set to true.
+	 *
+	 * @param infiniteMapRendering true when infinite map rendering should be enabled
+	 */
+	public void setInfiniteMapRendering(boolean infiniteMapRendering)
+	{
+		this.infiniteMapRendering = infiniteMapRendering;
+	}
+
+	/**
+	 * @return true if infinite map rendering is enabled
+	 */
+	public boolean isInfiniteMapRendering()
+	{
+		return horizontalWrapped || infiniteMapRendering;
 	}
 
 	/**


### PR DESCRIPTION
The idea of this pull request is to make it possible to (optionally) render a single map:

![single](https://cloud.githubusercontent.com/assets/1519324/18121009/bc2598e4-6f62-11e6-859c-1146a8892c3a.PNG)

instead of infinite one:

![infinite](https://cloud.githubusercontent.com/assets/1519324/18120933/6e9b210c-6f62-11e6-8019-38facb669ef5.png)

which is the default way the map is rendered.

In order to make this configurable a 
`public void setInfiniteMapRendering(boolean infiniteMapRendering)`
setter was added.
