### PR TITLE
Fixed use of deprecated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The content of this project are also available at *Maven Central* and can be ref
 #### What we plan to do ..
 
  * Fix bugs that were posted on http://java.net/jira/browse/SWINGX_WS ( mostly complete )
+ * Fix use of deprecated code
 
 #### License
 This project has been licensed under the GNU Lesser General Public License (LGPL)

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ The content of this project are also available at *Maven Central* and can be ref
  * Fixed thread leak when setting new TileFactory
  * Supports OSGi bundles (contains MANIFEST.MF)
  * Supports Maven dependency management
+ * Fixed use of deprecated code
  
 #### What we plan to do ..
 
  * Fix bugs that were posted on http://java.net/jira/browse/SWINGX_WS ( mostly complete )
- * Fix use of deprecated code
 
 #### License
 This project has been licensed under the GNU Lesser General Public License (LGPL)

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/input/PanMouseInputListener.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/input/PanMouseInputListener.java
@@ -54,14 +54,6 @@ public class PanMouseInputListener extends MouseInputAdapter
 				y += prev.y - current.y;
 		}
 
-		if (!viewer.isNegativeYAllowed())
-		{
-			if (y < 0)
-			{
-				y = 0;
-			}
-		}
-
 		int maxHeight = (int) (viewer.getTileFactory().getMapSize(viewer.getZoom()).getHeight() * viewer
 				.getTileFactory().getTileSize(viewer.getZoom()));
 		if (y > maxHeight)


### PR DESCRIPTION
Method isNegativeYAllowed() always returns true. In PanMouseInputListener class condition "if" with this method will never be true, therefore, consider it appropriate to remove this condition.