### PR TITLE
add the functionality to disable panning

### DIFF
--- a/jxmapviewer2/src/main/java/org/jxmapviewer/JXMapViewer.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/JXMapViewer.java
@@ -109,6 +109,12 @@ public class JXMapViewer extends JPanel implements DesignMode
 	private boolean horizontalWrapped = true;
 	private boolean infiniteMapRendering = true;
 
+    /**
+     * If true, panning with the mouse should take place. If false, panning should not happen. Does not disable 
+     * explicit setting of position via {@link setCenter}.
+     */
+    private boolean panningEnabled = true;
+    
 	/**
 	 * Create a new JXMapViewer. By default it will use the EmptyTileFactory
 	 */
@@ -869,4 +875,22 @@ public class JXMapViewer extends JPanel implements DesignMode
 	{
 		return true;
 	}
+
+    /**
+     * Enables or disables panning.
+     * Useful for performing selections on the map.
+     * @param enabled if true, panning is enabled (the default), if false, panning is disabled
+     */
+    public void setPanEnabled(boolean enabled)
+    {
+        this.panningEnabled = enabled;
+    }
+
+    /**
+     * Returns whether panning is enabled. If it is disabled, panning should not occur. (Used primarily by {@link PanMouseInputListener}
+     */
+    public boolean isPanningEnabled()
+    {
+        return this.panningEnabled;
+    }
 }

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/input/PanMouseInputListener.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/input/PanMouseInputListener.java
@@ -33,7 +33,9 @@ public class PanMouseInputListener extends MouseInputAdapter
 	{
 		if (!SwingUtilities.isLeftMouseButton(evt))
 			return;
-
+        if (!viewer.isPanningEnabled())
+            return;
+        
 		prev = evt.getPoint();
 		priorCursor = viewer.getCursor();
 		viewer.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
@@ -44,7 +46,9 @@ public class PanMouseInputListener extends MouseInputAdapter
 	{
 		if (!SwingUtilities.isLeftMouseButton(evt))
 			return;
-
+        if (!viewer.isPanningEnabled())
+            return;
+        
 		Point current = evt.getPoint();
 		double x = viewer.getCenter().getX();
 		double y = viewer.getCenter().getY();


### PR DESCRIPTION
The ability to disable panning enables creating user interfaces which can do various kinds of unit selection on the basis of <ctrl> or <shift> being held down while dragging the mouse (what we use this functionality for).