### PR TITLE
Load tiles from zip archive instead of online tileserver or file based on local disk

### DIFF
--- a/jxmapviewer2/src/main/java/org/jxmapviewer/ZipTileFactoryInfo.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/ZipTileFactoryInfo.java
@@ -1,0 +1,42 @@
+package org.jxmapviewer;
+
+import org.jxmapviewer.viewer.TileFactoryInfo;
+
+/**
+ *
+ * @author Ruediger34
+ */
+public class ZipTileFactoryInfo extends TileFactoryInfo {
+
+    private static final int max = 19;
+
+    /**
+     * Default constructor
+     */
+    public ZipTileFactoryInfo() {
+        this("Mapnik", "./maparchive.zip", 256);
+    }
+
+    /**
+     * Creats a TileFactoryInfo for loading tiles from an Zip Archive
+     *
+     * @param name     the folder name that contains tiles inside the zip archive
+     * @param baseURL  the FilePath to the archive
+     * @param tileSize specifies the tile size in the archive
+     *       
+     */
+    public ZipTileFactoryInfo(String name, String baseURL, int tileSize) {     
+        super(name, 1, max - 2, max, 
+                tileSize, true, true,   // tile size and x/y orientation is normal
+                baseURL,  
+                "x", "y", "z", true);     // 5/15/10.png        
+    }
+
+    @Override
+    public String getTileUrl(int x, int y, int zoom) {
+        zoom = max - zoom;
+        String url = this.baseURL + "/" + zoom + "/" + x + "/" + y + ".png";
+        return url;
+    }
+}
+

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/TileFactoryInfo.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/TileFactoryInfo.java
@@ -56,10 +56,11 @@ public class TileFactoryInfo
     private boolean yt2b = true;
 
     private int defaultZoomLevel;
-
+  
     /** A name for this info. */
     private String name;
-
+    private boolean zipArchive = false;
+    
     /**
      * Creates a new instance of TileFactoryInfo. Note that TileFactoryInfo should be considered invariate, meaning that
      * subclasses should ensure all of the properties stay the same after the class is constructed. Returning different
@@ -87,7 +88,38 @@ public class TileFactoryInfo
         this("name not provided", minimumZoomLevel, maximumZoomLevel, totalMapZoom, tileSize, xr2l, yt2b, baseURL,
                 xparam, yparam, zparam);
     }
-
+      
+    /**
+     * Creates a new instance of TileFactoryInfo.Note that TileFactoryInfo should be considered invariate, meaning that
+       subclasses should ensure all of the properties stay the same after the class is constructed.Returning different
+       values of getTileSize() for example is considered an error and may result in unexpected behavior.
+     * @param name the folder name that contains tiles inside the zip archive
+     * @param minimumZoomLevel The minimum zoom level
+     * @param maximumZoomLevel the maximum zoom level
+     * @param totalMapZoom the top zoom level, essentially the height of the pyramid
+     * @param tileSize the size of the tiles in pixels (must be square)
+     * @param xr2l if the x goes r to l (is this backwards?)
+     * @param yt2b if the y goes top to bottom
+     * @param baseURL the base url for grabbing tiles
+     * @param xparam the x parameter for the tile url
+     * @param yparam the y parameter for the tile url
+     * @param zparam the z parameter for the tile url
+     * @param zipArchive if the tiles should be loaded from a zip archive
+     */
+    /*
+     * @param xr2l true if tile x is measured from the far left of the map to the far right, or else false if based on
+     * the center line.
+     * @param yt2b true if tile y is measured from the top (north pole) to the bottom (south pole) or else false if
+     * based on the equator.
+     */
+    public TileFactoryInfo(String name, int minimumZoomLevel, int maximumZoomLevel, int totalMapZoom, int tileSize, boolean xr2l,
+            boolean yt2b, String baseURL, String xparam, String yparam, String zparam, boolean zipArchive)
+    {
+        this(name, minimumZoomLevel, maximumZoomLevel, totalMapZoom, tileSize, xr2l, yt2b, baseURL,
+                xparam, yparam, zparam);
+        this.zipArchive = zipArchive;
+    }
+    
     /**
      * Creates a new instance of TileFactoryInfo. Note that TileFactoryInfo should be considered invariate, meaning that
      * subclasses should ensure all of the properties stay the same after the class is constructed. Returning different
@@ -321,5 +353,11 @@ public class TileFactoryInfo
         return baseURL;
     }
 
-    
+    /**
+     * @return if the tiles are requested from a zip archive
+     */
+    public boolean isZipArchive() {
+        return zipArchive;
+    }
+  
 }


### PR DESCRIPTION
In my use case jxmapviewer load the tiles offline (file based, without connection to a tileserver, see also #72).
Currently I have a zip Archive which contains two tile sources (openstreetmap-carto and opentopomap renderd tiles), but the archive must be unzipped before jxmapviewer can use the tiles. 

With this pull request it's no longer necessary to unzip the tiles from the archive which results in less disk space usage and faster copy of new map data (zip archive) because unzipping all tiles (very much) needs a lot of time.

What I have done:
- Introduced a new ZipTileFactoryInfo that is able to load tiles from zip archives
- extended TileFactoryInfo with "zipArchive" - property to specify if tiles are loaded from an archives
		- added new constructor to create the ZipTileFactoryInfo
- extended AbstractTileFactory constructor to initialize the zipfile properties
		- added code to load tiles from an archive

What do you think about that?
If you have suggestions to improve the code, please let me know!