### PR TITLE
Let the TileFactory try and re-load tiles that failed load

### DIFF
--- a/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/Tile.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/Tile.java
@@ -51,6 +51,14 @@ public class Tile extends AbstractBean
      */
 
     private boolean loaded = false;
+    
+    
+    /**
+     * Indicates that the loading has failed.
+     */
+    private boolean loadFailed = false;
+    
+    
     /**
      * The zoom level this tile is for
      */
@@ -115,6 +123,25 @@ public class Tile extends AbstractBean
         this.loaded = loaded;
         firePropertyChange("loaded", old, isLoaded());
     }
+      
+    /**
+     * Indicates if this tile's underlying image failed loading.
+     * @return true if the Tile has been loaded
+     */
+    public synchronized boolean loadingFailed()
+    {
+        return loadFailed;
+    }
+
+    /**
+     * Toggles the failed state
+     * @param fail the fail flag
+     */
+    synchronized void setLoadingFailed(boolean fail)
+    {
+        loadFailed = fail;
+    }
+    
 
     /**
      * @return the Image associated with this Tile. This is a read only property This may return null at any time,


### PR DESCRIPTION
First, this is a great project.  It's working wonderfully. One issue I have, if the internet connection is lost, tiles will fail to load unless they are cached. The tile shows grey with the "loading" icon. If the internet connection is re-established, the tiles that failed to load will never be reloaded. This is because they are still in the tileMap, set as not loading, but with no image. This pull request creates a new property in the Tile class that indicates if the tile failed load after all attempts failed. Then, when the tileMap is queried, the failed tile is removed from the map. This will allow the factory to retry the load in the future. I've tested this and found that once a connection is re-established, the greyed out tiles reload properly. 