### PR TITLE
Catch NullPointer if properties file not found

### DIFF
--- a/jxmapviewer2/src/main/java/org/jxmapviewer/util/ProjectProperties.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/util/ProjectProperties.java
@@ -34,11 +34,16 @@ public enum ProjectProperties {
         try {
             ClassLoader classloader = Thread.currentThread().getContextClassLoader();
             is = classloader.getResourceAsStream(PROPERTIES_FILE);
-            props.load(is);
-            log.debug("Properties successfully loaded.");
-
+            if (is != null) {
+                props.load(is);
+                log.debug("Properties successfully loaded.");
+            } else {
+                log.warn("Project properties file not found. Set default values.");
+                props.put(PROP_NAME, "JxMapViewer");
+                props.put(PROP_VERSION, "1.0");
+            }
         }
-        catch (IOException | NullPointerException e) {
+        catch (IOException e) {
             log.warn("Unable to read project properties.", e);
             props.put(PROP_NAME, "JxMapViewer");
             props.put(PROP_VERSION, "1.0");

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/util/ProjectProperties.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/util/ProjectProperties.java
@@ -38,7 +38,7 @@ public enum ProjectProperties {
             log.debug("Properties successfully loaded.");
 
         }
-        catch (IOException e) {
+        catch (IOException | NullPointerException e) {
             log.warn("Unable to read project properties.", e);
             props.put(PROP_NAME, "JxMapViewer");
             props.put(PROP_VERSION, "1.0");


### PR DESCRIPTION
If the map viewer is loaded from an external jar at runtime, the properties file cannot be loaded. A NullPointerException is thrown.

This PR ensures that the map viewer can continue to run if the file is not found.