### PR TITLE
Added callback to inject custom request properties for tile requests

### DIFF
--- a/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/AbstractTileFactory.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/AbstractTileFactory.java
@@ -429,6 +429,7 @@ public abstract class AbstractTileFactory extends TileFactory
             if (ins == null) {
                 URLConnection connection = url.openConnection();
                 connection.setRequestProperty("User-Agent", userAgent);
+                addCustomRequestProperties(connection);
                 ins = connection.getInputStream();
             }
             try {
@@ -453,5 +454,16 @@ public abstract class AbstractTileFactory extends TileFactory
             }
             return bout.toByteArray();
         }
+    }
+
+    /**
+     * Adds custom request properties to the connection before sending the request.
+     * By default, no properties are added at all.
+     *
+     * @param connection connection for tile request
+     */
+    protected void addCustomRequestProperties(URLConnection connection)
+    {
+        // no further headers by default
     }
 }


### PR DESCRIPTION
Using this callback, a custom TileFactory implementation can add request headers to the tile request, e.g. when the tile server requires authentication. For example, when using OAuth 2.0, the "Authorization" HTTP header can be added to send a bearer token along with the request.