### PR TITLE
Minor Javadoc updates

### DIFF
--- a/jxmapviewer2/src/main/java/org/jxmapviewer/JXMapKit.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/JXMapKit.java
@@ -54,10 +54,7 @@ import org.jxmapviewer.viewer.WaypointPainter;
  * <PRE><CODE>jxMapKit.setMiniMapVisible(false);</CODE></PRE>
  *
  * <p>
- * The JXMapViewer is preconfigured to connect to maps.swinglabs.org which
- * serves up global satellite imagery from NASA's
- * <a href="http://earthobservatory.nasa.gov/Newsroom/BlueMarble/">Blue
- * Marble NG</a> image collection.
+ * The JXMapViewer is preconfigured to connect to OpenStreetMap.
  * </p>
  * @author joshy
  */

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/JXMapViewer.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/JXMapViewer.java
@@ -43,9 +43,6 @@ import org.jxmapviewer.viewer.empty.EmptyTileFactory;
  * A tile oriented map component that can easily be used with tile sources
  * on the web like Google and Yahoo maps, satellite data such as NASA imagery,
  * and also with file based sources like pre-processed NASA images.
- * A known map provider can be used with the SLMapServerInfo,
- * which will connect to a 2km resolution version of NASA's Blue Marble Next Generation
- * imagery. @see SLMapServerInfo for more information.
  *
  * Note, the JXMapViewer has three center point properties.  The <B>addressLocation</B> property
  * represents an abstract center of the map. This would usually be something like the first item


### PR DESCRIPTION
Removes misleading javadoc about default connection for jxmapkit and SLMapServerInfo which no longer appears to exist.