### PR TITLE
Add support for disabling input handlers.

### DIFF
--- a/jxmapviewer2/src/main/java/org/jxmapviewer/input/CenterMapListener.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/input/CenterMapListener.java
@@ -11,16 +11,22 @@ import javax.swing.SwingUtilities;
 import org.jxmapviewer.JXMapViewer;
 
 /**
- * Centers the map on the mouse cursor
- * if left is double-clicked or middle mouse
- * button is pressed.
+ * Centers the map on the mouse cursor.
+ *
+ * <p>To perform the centering operation, the left button is double-clicked or
+ * middle mouse button is pressed
+ *
+ * <p>This input listener can be disabled. It is enabled by default. When it is
+ * disabled, mouse wheel events will have no effect.
+ *
  * @author Martin Steiger
  * @author joshy
  */
-public class CenterMapListener extends MouseAdapter
+public class CenterMapListener extends MouseAdapter implements DisableableInputAdapter
 {
     private JXMapViewer viewer;
-    
+    private boolean enabled;
+
     /**
      * @param viewer the jxmapviewer
      */
@@ -32,6 +38,10 @@ public class CenterMapListener extends MouseAdapter
     @Override
     public void mousePressed(MouseEvent evt)
     {
+        if (!enabled)
+        {
+            return;
+        }
         boolean left = SwingUtilities.isLeftMouseButton(evt);
         boolean middle = SwingUtilities.isMiddleMouseButton(evt);
         boolean doubleClick = (evt.getClickCount() == 2);
@@ -51,6 +61,27 @@ public class CenterMapListener extends MouseAdapter
                 viewer.setZoom(viewer.getZoom() - 1);
         viewer.repaint();
     }
-}
 
+    /**
+     * Check if this input listener is enabled.
+     * @return true if it is enabled, otherwise false.
+     */
+    @Override
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    /**
+     * Set whether this input listener is enabled or not.
+     *
+     * If it is not enabled, user input will have no effect.
+     * @param enabled true to enable, false to disable.
+     */
+    @Override
+    public void setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+    }
+}
 

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/input/DisableableInputAdapter.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/input/DisableableInputAdapter.java
@@ -1,0 +1,22 @@
+package org.jxmapviewer.input;
+
+/**
+ * An interface for input adapters that can be disabled.
+ */
+public interface DisableableInputAdapter {
+
+    /**
+     * Check if this input listener is enabled.
+     * @return true if it is enabled, otherwise false.
+     */
+    boolean isEnabled();
+
+    /**
+     * Set whether this input listener is enabled or not.
+     *
+     * If it is not enabled, user input will have no effect.
+     * @param enabled true to enable, false to disable.
+     */
+    void setEnabled(boolean enabled);
+    
+}

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/input/DisableableMouseWheelListener.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/input/DisableableMouseWheelListener.java
@@ -1,0 +1,47 @@
+package org.jxmapviewer.input;
+
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
+import org.jxmapviewer.JXMapViewer;
+
+/**
+ * Abstract mouse wheel event listener.
+ *
+ * <p>This input listener can be disabled. It is enabled by default. When it is
+ * disabled, mouse wheel events will have no effect.
+ */
+public abstract class DisableableMouseWheelListener implements MouseWheelListener, DisableableInputAdapter {
+    protected JXMapViewer viewer;
+    protected boolean enabled;
+
+    /**
+     * Constructor.
+     * @param viewer the map viewer to attach this listener to.
+     */
+    public DisableableMouseWheelListener(JXMapViewer viewer) {
+        this.viewer = viewer;
+    }
+
+    @Override
+    public abstract void mouseWheelMoved(MouseWheelEvent evt);
+
+    /**
+     * Check if this input listener is enabled.
+     * @return true if it is enabled, otherwise false.
+     */
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Set whether this input listener is enabled or not.
+     *
+     * If it is not enabled, user input will have no effect.
+     * @param enabled true to enable, false to disable.
+     */
+    @Override
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/input/PanKeyListener.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/input/PanKeyListener.java
@@ -9,15 +9,19 @@ import java.awt.geom.Point2D;
 import org.jxmapviewer.JXMapViewer;
 
 /**
- * used to pan using the arrow keys
+ * Used to pan the map using the arrow keys.
+ *
+ * <p>This input listener can be disabled. When it is disabled, key events will have no effect.
+ *
  * @author joshy
  */
-public class PanKeyListener extends KeyAdapter
+public class PanKeyListener extends KeyAdapter implements DisableableInputAdapter
 {
     private static final int OFFSET = 10;
 
     private JXMapViewer viewer;
-    
+    private boolean enabled;
+
     /**
      * @param viewer the jxmapviewer
      */
@@ -29,6 +33,10 @@ public class PanKeyListener extends KeyAdapter
     @Override
     public void keyPressed(KeyEvent e)
     {
+        if (!enabled)
+        {
+            return;
+        }
         int delta_x = 0;
         int delta_y = 0;
 
@@ -56,5 +64,27 @@ public class PanKeyListener extends KeyAdapter
             viewer.setCenter(new Point2D.Double(x, y));
             viewer.repaint();
         }
+    }
+
+    /**
+     * Check if this input listener is enabled.
+     * @return true if it is enabled, otherwise false.
+     */
+    @Override
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    /**
+     * Set whether this input listener is enabled or not.
+     *
+     * If it is not enabled, user input will have no effect.
+     * @param enabled true to enable, false to disable.
+     */
+    @Override
+    public void setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
     }
 }

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/input/PanMouseInputListener.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/input/PanMouseInputListener.java
@@ -11,15 +11,20 @@ import javax.swing.event.MouseInputAdapter;
 import org.jxmapviewer.JXMapViewer;
 
 /**
- * Used to pan using press and drag mouse gestures
+ * Used to pan using press and drag mouse gestures.
+ *
+ * <p>This input listener can be disabled. It is enabled by default. When it is
+ * disabled, mouse events will have no effect.
+ *
  * @author joshy
  */
-public class PanMouseInputListener extends MouseInputAdapter
+public class PanMouseInputListener extends MouseInputAdapter implements DisableableInputAdapter
 {
     private Point prev;
     private JXMapViewer viewer;
     private Cursor priorCursor;
-    
+    private boolean enabled = true;
+
     /**
      * @param viewer the jxmapviewer
      */
@@ -31,6 +36,10 @@ public class PanMouseInputListener extends MouseInputAdapter
     @Override
     public void mousePressed(MouseEvent evt)
     {
+        if (!isEnabled())
+        {
+            return;
+        }
         if (!SwingUtilities.isLeftMouseButton(evt))
             return;
         if (!viewer.isPanningEnabled())
@@ -44,6 +53,10 @@ public class PanMouseInputListener extends MouseInputAdapter
     @Override
     public void mouseDragged(MouseEvent evt)
     {
+        if (!isEnabled())
+        {
+            return;
+        }
         if (!SwingUtilities.isLeftMouseButton(evt))
             return;
         if (!viewer.isPanningEnabled())
@@ -73,10 +86,36 @@ public class PanMouseInputListener extends MouseInputAdapter
     @Override
     public void mouseReleased(MouseEvent evt)
     {
+        if (!isEnabled())
+        {
+            return;
+        }
         if (!SwingUtilities.isLeftMouseButton(evt))
             return;
 
         prev = null;
         viewer.setCursor(priorCursor);
+    }
+
+    /**
+     * Check if this input listener is enabled.
+     * @return true if it is enabled, otherwise false.
+     */
+    @Override
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    /**
+     * Set whether this input listener is enabled or not.
+     *
+     * If it is not enabled, user input will have no effect.
+     * @param enabled true to enable, false to disable.
+     */
+    @Override
+    public void setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
     }
 }

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/input/ZoomMouseWheelListenerCenter.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/input/ZoomMouseWheelListenerCenter.java
@@ -7,24 +7,27 @@ import java.awt.event.MouseWheelListener;
 import org.jxmapviewer.JXMapViewer;
 
 /**
- * zooms using the mouse wheel on the view center
+ * Zooms using the mouse wheel on the view center.
+ *
  * @author joshy
  */
-public class ZoomMouseWheelListenerCenter implements MouseWheelListener
+public class ZoomMouseWheelListenerCenter extends DisableableMouseWheelListener implements MouseWheelListener, DisableableInputAdapter
 {
-    private JXMapViewer viewer;
-    
     /**
      * @param viewer the jxmapviewer
      */
     public ZoomMouseWheelListenerCenter(JXMapViewer viewer)
     {
-        this.viewer = viewer;
+        super(viewer);
     }
 
     @Override
     public void mouseWheelMoved(MouseWheelEvent e)
     {
+        if (!enabled)
+        {
+            return;
+        }
         viewer.setZoom(viewer.getZoom() + e.getWheelRotation());
     }
 }

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/input/ZoomMouseWheelListenerCursor.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/input/ZoomMouseWheelListenerCursor.java
@@ -11,25 +11,30 @@ import java.awt.geom.Point2D;
 import org.jxmapviewer.JXMapViewer;
 
 /**
- * zooms to the current mouse cursor 
- * using the mouse wheel
+ * Zooms to the current mouse cursor using the mouse wheel.
+ *
+ * <p>This input listener can be disabled. It is enabled by default. When it is
+ * disabled, mouse wheel events will have no effect.
+ *
  * @author Martin Steiger
  */
-public class ZoomMouseWheelListenerCursor implements MouseWheelListener
+public class ZoomMouseWheelListenerCursor extends DisableableMouseWheelListener implements MouseWheelListener, DisableableInputAdapter
 {
-    private JXMapViewer viewer;
-    
     /**
      * @param viewer the jxmapviewer
      */
     public ZoomMouseWheelListenerCursor(JXMapViewer viewer)
     {
-        this.viewer = viewer;
+        super(viewer);
     }
 
     @Override
     public void mouseWheelMoved(MouseWheelEvent evt)
     {
+        if (!enabled)
+        {
+            return;
+        }
         Point current = evt.getPoint();
         Rectangle bound = viewer.getViewportBounds();
         
@@ -52,4 +57,5 @@ public class ZoomMouseWheelListenerCursor implements MouseWheelListener
 
         viewer.setCenter(new Point2D.Double(x, y));
     }
+
 }


### PR DESCRIPTION
The use case is where the map is switchable between automatic control / zoom, and manual control.
If both are happening, there is ugly flickering. This allows input handlers to be disabled without
removing them.