### PR TITLE
Fix offset error with Graphics2D translate

### DIFF
--- a/examples/src/sample4_fancy/FancyWaypointRenderer.java
+++ b/examples/src/sample4_fancy/FancyWaypointRenderer.java
@@ -12,6 +12,7 @@ package sample4_fancy;
 import java.awt.Color;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 import java.net.URL;
@@ -98,7 +99,12 @@ public class FancyWaypointRenderer implements WaypointRenderer<MyWaypoint>
         int x = (int)point.getX();
         int y = (int)point.getY();
 
-        g.drawImage(myImg, x -myImg.getWidth() / 2, y -myImg.getHeight(), null);
+        Rectangle viewportBounds = viewer.getViewportBounds();
+
+        int dx = (int) -viewportBounds.getX();
+        int dy = (int) -viewportBounds.getY();
+
+        g.drawImage(myImg, x -myImg.getWidth() / 2 + dx, y -myImg.getHeight() + dy, null);
 
         String label = w.getLabel();
 
@@ -109,7 +115,14 @@ public class FancyWaypointRenderer implements WaypointRenderer<MyWaypoint>
         int th = 1 + metrics.getAscent();
 
 //        g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
-        g.drawString(label, x - tw / 2, y + th - myImg.getHeight());
+        g.drawString(label, x - tw / 2 + dx, y + th - myImg.getHeight() + dy);
+
+
+        // paints a blue circle with an internal white circle
+        g.setColor(Color.BLUE);
+        g.fillOval(x-7+dx, y-7+dy, 14, 14);
+        g.setColor(Color.WHITE);
+        g.fillOval(x-4+dx, y-4+dy, 8, 8);
 
         g.dispose();
     }

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/DefaultWaypointRenderer.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/DefaultWaypointRenderer.java
@@ -10,6 +10,7 @@
 package org.jxmapviewer.viewer;
 
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 
@@ -26,7 +27,7 @@ import org.jxmapviewer.JXMapViewer;
 public class DefaultWaypointRenderer implements WaypointRenderer<Waypoint>
 {
     private static final Log log = LogFactory.getLog(DefaultWaypointRenderer.class);
-    
+
     private BufferedImage img = null;
 
     /**
@@ -51,10 +52,12 @@ public class DefaultWaypointRenderer implements WaypointRenderer<Waypoint>
             return;
 
         Point2D point = map.getTileFactory().geoToPixel(w.getPosition(), map.getZoom());
-        
-        int x = (int)point.getX() -img.getWidth() / 2;
-        int y = (int)point.getY() -img.getHeight();
-        
+
+        Rectangle viewportBounds = map.getViewportBounds();
+
+        int x = (int)(point.getX() -img.getWidth() / 2 -viewportBounds.getX());
+        int y = (int)(point.getY() -img.getHeight() -viewportBounds.getY());
+
         g.drawImage(img, x, y, null);
     }
 }

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/WaypointPainter.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/WaypointPainter.java
@@ -74,17 +74,10 @@ public class WaypointPainter<W extends Waypoint> extends AbstractPainter<JXMapVi
             return;
         }
 
-        Rectangle viewportBounds = map.getViewportBounds();
-
-        g.translate(-viewportBounds.getX(), -viewportBounds.getY());
-
         for (W w : getWaypoints())
         {
             renderer.paintWaypoint(g, map, w);
         }
-
-        g.translate(viewportBounds.getX(), viewportBounds.getY());
-
     }
 
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1820007/146673714-239814b7-2202-4fa4-a118-70ec42aed0d1.png)

Fixes the error when displaying elements at high zoom levels. It looks like a rounding error, but I don't think it is.

```
dx: -35180458 (int)
dx: -35180458,000000000000 (computed as double)
```

Unfortunately, this is a **breaking change**  for `WaypointRenderer` implementations.

Fixes #115 