### PR TITLE
Basic support for tiles from GeoPackage files.

### DIFF
--- a/jxmapviewer2/build.gradle
+++ b/jxmapviewer2/build.gradle
@@ -15,6 +15,7 @@ repositories {
 
 dependencies {
     implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'
+    implementation group: 'mil.nga.geopackage', name: 'geopackage', version: '6.4.0'
 }
 
 

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/geopackage/GeopackageTileFactory.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/geopackage/GeopackageTileFactory.java
@@ -1,0 +1,101 @@
+package org.jxmapviewer.viewer.geopackage;
+
+import java.io.File;
+import java.awt.image.BufferedImage;
+
+import org.jxmapviewer.viewer.Tile;
+import org.jxmapviewer.viewer.TileFactory;
+import org.jxmapviewer.viewer.TileFactoryInfo;
+
+import mil.nga.geopackage.GeoPackage;
+import mil.nga.geopackage.GeoPackageManager;
+import mil.nga.geopackage.tiles.GeoPackageTile;
+import mil.nga.geopackage.tiles.GeoPackageTileRetriever;
+import mil.nga.geopackage.tiles.ImageUtils;
+import mil.nga.geopackage.tiles.user.TileDao;
+
+/**
+ * TileFactory to load tiles from GeoPackage files.
+ * 
+ * GeoPackage is a file format based on an SQLite database with tables that 
+ * store raster map data as tile pyramids, vector features and metadata about 
+ * them.
+ * 
+ * Only raster tile pyramid tables are supported, with the tiles being 256x256
+ * pixels in PNG format.
+ * 
+ * @author Georgios Migdos
+ */
+public class GeopackageTileFactory extends TileFactory {
+
+    private GeoPackage geoPackage;
+    private TileDao tileDao;
+    private int maxZoom;
+
+    /** 
+     * Creates a new instance of GeopackageTileFactory using the specified info. 
+     * @param info the tile factory info
+     */
+    public GeopackageTileFactory(File geopackageFile, String table, int minZoom, int maxZoom)
+    {
+        super(new TileFactoryInfo(minZoom-1, maxZoom-1, maxZoom-minZoom, 256, true, true, "", "x", "y", "z"));
+        this.geoPackage = GeoPackageManager.open(geopackageFile);
+        this.tileDao = geoPackage.getTileDao(table);
+        this.maxZoom = maxZoom-1;
+    }
+
+    /**
+     * Gets an instance of an empty tile for the given tile position and zoom on the world map.
+     * @param x The tile's x position on the world map.
+     * @param y The tile's y position on the world map.
+     * @param zoom The current zoom level.
+     */
+    @Override
+    public Tile getTile(int x, int y, int zoom)
+    {
+        // Retrieve Tiles by XYZ
+        GeoPackageTileRetriever retriever = new GeoPackageTileRetriever(tileDao, ImageUtils.IMAGE_FORMAT_PNG);
+        GeoPackageTile geoPackageTile = retriever.getTile(x, y, maxZoom - zoom);
+        if (geoPackageTile != null) {
+            BufferedImage tileImage = geoPackageTile.getImage();
+            return new Tile(x, y, zoom){
+
+                public synchronized boolean isLoaded() {
+                    return  true;
+                }
+
+                public BufferedImage getImage() {
+                    return tileImage;
+                };
+            };
+        } else {
+            return new Tile(x, y, zoom){
+                @Override
+                public synchronized boolean isLoaded() {
+                    return  false;
+                }
+
+                @Override
+                public synchronized boolean loadingFailed() {
+                    return true;
+                }
+            };
+        }
+    }
+
+    @Override
+    public void dispose()
+    {
+      geoPackage.close();
+    }
+
+    /**
+     * Override this method to load the tile using, for example, an <code>ExecutorService</code>.
+     * @param tile The tile to load.
+     */
+    @Override
+    protected void startLoading(Tile tile)
+    {
+        // noop
+    }
+}


### PR DESCRIPTION
Implements basic support (direct loading, no caching) of tiles from GeoPackage files.

Merging this would introduce a dependency to NGA's GeoPackage Java (https://github.com/ngageoint/geopackage-java).

This could be useful as GeoPackage provides an easy to use file format to transfer raster tile pyramids (similar to MBTiles, but an OGC standard) in addition to vector map data.

For info on GeoPackage please see: https://www.geopackage.org/

An example is available at [cyberpython/jxmapviewer2@931329d260d634c44c5cef54d3ae86af5ce46216](https://github.com/cyberpython/jxmapviewer2/blob/931329d260d634c44c5cef54d3ae86af5ce46216/examples/src/sample12_geopackage/Sample12.java) (note that the JxMapViewer2 version referenced in the `pom.xml` is fictional as this merge request is about the functionality used by the example).
