### PR TITLE
 JXMapViewer.zoomToBestFit()

### DIFF
--- a/jxmapviewer2/build.gradle
+++ b/jxmapviewer2/build.gradle
@@ -15,8 +15,10 @@ repositories {
 
 dependencies {
     implementation group: 'commons-logging', name: 'commons-logging', version: '1.2'
+    // JUnit 4 requires Java >=5
+    // JUnit 5 requires Java >=8
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
 }
-
 
 uploadArchives {
     repositories {

--- a/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/GeoBounds.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/viewer/GeoBounds.java
@@ -33,10 +33,10 @@ public class GeoBounds
      */
     public GeoBounds(Set<GeoPosition> geoPositions)
     {
-        if (geoPositions == null || geoPositions.size() < 2)
+        if (geoPositions == null || geoPositions.size() == 0)
         {
             throw new IllegalArgumentException("The attribute 'geoPositions' cannot be null and must "
-                    + "have 2 or more elements.");
+                    + "have 1 or more elements.");
         }
         double minLat = Integer.MAX_VALUE;
         double minLng = Integer.MAX_VALUE;
@@ -61,11 +61,11 @@ public class GeoBounds
      */
     private void setRect(double minLat, double minLng, double maxLat, double maxLng)
     {
-        if (!(minLat < maxLat))
+        if (minLat > maxLat)
         {
-            throw new IllegalArgumentException("GeoBounds is not valid - minLat must be less that maxLat.");
+            throw new IllegalArgumentException("GeoBounds is not valid - minLat must be less than or equal maxLat.");
         }
-        if (!(minLng < maxLng))
+        if (minLng > maxLng)
         {
             if (minLng > 0 && minLng < 180 && maxLng < 0)
             {
@@ -79,7 +79,7 @@ public class GeoBounds
             {
                 rects = new Rectangle2D[] { new Rectangle2D.Double(minLng, minLat, maxLng - minLng, maxLat - minLat) };
 
-                throw new IllegalArgumentException("GeoBounds is not valid - minLng must be less that maxLng or "
+                throw new IllegalArgumentException("GeoBounds is not valid - minLng must be less than or equal maxLng or "
                         + "minLng must be greater than 0 and maxLng must be less than 0.");
             }
         }

--- a/jxmapviewer2/src/test/java/org/jxmapviewer/GeoBoundsTest.java
+++ b/jxmapviewer2/src/test/java/org/jxmapviewer/GeoBoundsTest.java
@@ -1,0 +1,67 @@
+package org.jxmapviewer;
+
+import org.junit.Test;
+import org.jxmapviewer.viewer.GeoBounds;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertTrue;
+
+public class GeoBoundsTest {
+    @Test
+    public void geoBounds_with_extend() {
+        GeoBounds bounds = new GeoBounds(50.0, 8.0, 50.1, 8.1);
+    }
+
+    @Test
+    public void geoBounds_horizontal_track() {
+        GeoBounds bounds = new GeoBounds(50.0, 8.0, 50.0, 8.1);
+    }
+
+    @Test
+    public void geoBounds_vertical_track() {
+        GeoBounds bounds = new GeoBounds(50.0, 8.0, 50.1, 8.0);
+    }
+
+    @Test
+    public void geoBounds_point() {
+        GeoBounds bounds = new GeoBounds(50.0, 8.0, 50.0, 8.0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void geoBounds_invalid_latitudes() {
+        GeoBounds bounds = new GeoBounds(50.1, 8.0, 50.0, 8.1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void geoBounds_invalid_longitudes() {
+        GeoBounds bounds = new GeoBounds(50.0, 8.1, 50.1, 8.0);
+    }
+
+    @Test
+    public void geoBounds_intersect() {
+        GeoBounds bounds1 = new GeoBounds(50.0, 8.0, 50.2, 8.2);
+        GeoBounds bounds2 = new GeoBounds(50.1, 8.1, 50.3, 8.3);
+        assertTrue(bounds1.intersects(bounds2));
+    }
+
+    @Test
+    public void geoBounds_do_not_intersect() {
+        GeoBounds bounds1 = new GeoBounds(50.0, 8.0, 50.1, 8.1);
+        GeoBounds bounds2 = new GeoBounds(50.2, 8.2, 50.3, 8.3);
+        assertFalse(bounds1.intersects(bounds2));
+    }
+
+    @Test
+    public void geoBounds_horizontal_and_vertical_track_do_not_intersect() {
+        GeoBounds horizontalTrackBounds = new GeoBounds(50.0, 7.9, 50.0, 8.1);
+        GeoBounds verticalTrackBounds = new GeoBounds(49.9, 8.0, 50.1, 8.0);
+        assertFalse(horizontalTrackBounds.intersects(verticalTrackBounds));
+    }
+
+    @Test
+    public void geoBounds_pacific_bounds_intersect() {
+        GeoBounds pacific1Bounds = new GeoBounds(50.0, 179.9, 50.2, -179.9);
+        GeoBounds pacific2Bounds = new GeoBounds(50.1, -180.0, 50.3, -179.8);
+        assertTrue(pacific1Bounds.intersects(pacific2Bounds));
+    }
+}

--- a/jxmapviewer2/src/test/java/org/jxmapviewer/JXMapViewerTest.java
+++ b/jxmapviewer2/src/test/java/org/jxmapviewer/JXMapViewerTest.java
@@ -1,10 +1,14 @@
 package org.jxmapviewer;
 
 import org.junit.Test;
+import org.jxmapviewer.viewer.DefaultTileFactory;
 import org.jxmapviewer.viewer.GeoPosition;
+import org.jxmapviewer.viewer.TileFactoryInfo;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class JXMapViewerTest {
 
@@ -14,12 +18,18 @@ public class JXMapViewerTest {
     @Test
     public void zoomToBestFit_diagonal_track() {
         JXMapViewer mapViewer = new JXMapViewer();
+
+        TileFactoryInfo info = new OSMTileFactoryInfo();
+        DefaultTileFactory tileFactory = new DefaultTileFactory(info);
+        mapViewer.setTileFactory(tileFactory);
+
         mapViewer.setSize(100, 100);
         GeoPosition frankfurt = new GeoPosition(50,  7, 0, 8, 41, 0);
         GeoPosition wiesbaden = new GeoPosition(50,  5, 0, 8, 14, 0);
         List<GeoPosition> track = Arrays.asList(frankfurt, wiesbaden);
 
         mapViewer.zoomToBestFit(new HashSet<GeoPosition>(track), 0.7);
+        assertEquals(12, mapViewer.getZoom());
     }
 
     /**
@@ -30,12 +40,18 @@ public class JXMapViewerTest {
     @Test
     public void zoomToBestFit_horizontal_track_same_latitude() {
         JXMapViewer mapViewer = new JXMapViewer();
+
+        TileFactoryInfo info = new OSMTileFactoryInfo();
+        DefaultTileFactory tileFactory = new DefaultTileFactory(info);
+        mapViewer.setTileFactory(tileFactory);
+
         mapViewer.setSize(100, 100);
         GeoPosition position1 = new GeoPosition(50,  5, 0, 8, 41, 0);
         GeoPosition position2 = new GeoPosition(50,  5, 0, 8, 14, 0);
         List<GeoPosition> track = Arrays.asList(position1, position2);
 
         mapViewer.zoomToBestFit(new HashSet<GeoPosition>(track), 0.7);
+        assertEquals(12, mapViewer.getZoom());
     }
 
     /**
@@ -47,11 +63,83 @@ public class JXMapViewerTest {
     @Test
     public void zoomToBestFit_vertical_track_same_longitude() {
         JXMapViewer mapViewer = new JXMapViewer();
+
+        TileFactoryInfo info = new OSMTileFactoryInfo();
+        DefaultTileFactory tileFactory = new DefaultTileFactory(info);
+        mapViewer.setTileFactory(tileFactory);
+
         mapViewer.setSize(100, 100);
-        GeoPosition position1 = new GeoPosition(50,  7, 0, 8, 41, 0);
-        GeoPosition position2 = new GeoPosition(50,  5, 0, 8, 41, 0);
+        GeoPosition position1 = new GeoPosition(50.7, 8.41);
+        GeoPosition position2 = new GeoPosition(50.5, 8.41);
         List<GeoPosition> track = Arrays.asList(position1, position2);
 
         mapViewer.zoomToBestFit(new HashSet<GeoPosition>(track), 0.7);
+        assertEquals(11, mapViewer.getZoom());
+    }
+
+    @Test
+    public void zoomToBestFit_slightly_not_vertical_track() {
+        JXMapViewer mapViewer = new JXMapViewer();
+
+        TileFactoryInfo info = new OSMTileFactoryInfo();
+        DefaultTileFactory tileFactory = new DefaultTileFactory(info);
+        mapViewer.setTileFactory(tileFactory);
+
+        mapViewer.setSize(100, 100);
+        GeoPosition position1 = new GeoPosition(50.7, 8.41);
+        GeoPosition position2 = new GeoPosition(50.5, 8.41001);
+        List<GeoPosition> track = Arrays.asList(position1, position2);
+
+        mapViewer.zoomToBestFit(new HashSet<GeoPosition>(track), 0.7);
+        assertEquals(11, mapViewer.getZoom());
+    }
+
+    /**
+     * zooms in as much as possible,
+     */
+    @Test
+    public void zoomToBestFit_point() {
+        JXMapViewer mapViewer = new JXMapViewer();
+
+        TileFactoryInfo info = new OSMTileFactoryInfo();
+        DefaultTileFactory tileFactory = new DefaultTileFactory(info);
+        mapViewer.setTileFactory(tileFactory);
+
+        mapViewer.setSize(100, 100);
+        GeoPosition position1 = new GeoPosition(50,  7, 0, 8, 41, 0);
+        GeoPosition position2 = new GeoPosition(50,  7, 0, 8, 41, 0);
+        List<GeoPosition> track = Arrays.asList(position1, position2);
+
+        mapViewer.zoomToBestFit(new HashSet<GeoPosition>(track), 0.7);
+        assertEquals(0, mapViewer.getZoom());
+    }
+
+    /**
+     * zooms in as much as possible,
+     */
+    @Test
+    public void zoomToBestFit_very_close_points() throws InterruptedException {
+        JXMapViewer mapViewer = new JXMapViewer();
+
+        TileFactoryInfo info = new OSMTileFactoryInfo();
+        DefaultTileFactory tileFactory = new DefaultTileFactory(info);
+        mapViewer.setTileFactory(tileFactory);
+
+        mapViewer.setSize(100, 100);
+        GeoPosition position1 = new GeoPosition(50.5, 8.3);
+        GeoPosition position2 = new GeoPosition(50.500000001, 8.300000001);
+        List<GeoPosition> track = Arrays.asList(position1, position2);
+
+        mapViewer.zoomToBestFit(new HashSet<GeoPosition>(track), 0.7);
+        assertEquals(0, mapViewer.getZoom());
+
+        /*
+        JFrame f = new JFrame();
+        f.setVisible(true);
+        f.setSize(200,200);
+        f.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        f.add(mapViewer);
+        Thread.sleep(5000);
+         */
     }
 }

--- a/jxmapviewer2/src/test/java/org/jxmapviewer/JXMapViewerTest.java
+++ b/jxmapviewer2/src/test/java/org/jxmapviewer/JXMapViewerTest.java
@@ -1,0 +1,56 @@
+package org.jxmapviewer;
+
+import org.junit.Test;
+import org.jxmapviewer.viewer.GeoPosition;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+public class JXMapViewerTest {
+
+    /**
+     * 21.10.2022: green
+     */
+    @Test
+    public void zoomToBestFit_diagonal_track() {
+        JXMapViewer mapViewer = new JXMapViewer();
+        mapViewer.setSize(100, 100);
+        GeoPosition frankfurt = new GeoPosition(50,  7, 0, 8, 41, 0);
+        GeoPosition wiesbaden = new GeoPosition(50,  5, 0, 8, 14, 0);
+        List<GeoPosition> track = Arrays.asList(frankfurt, wiesbaden);
+
+        mapViewer.zoomToBestFit(new HashSet<GeoPosition>(track), 0.7);
+    }
+
+    /**
+     *
+     * 21.10.2022: red: Method zoomToBestFit throws
+     * java.lang.IllegalArgumentException: GeoBounds is not valid - minLat must be less that maxLat.
+     */
+    @Test
+    public void zoomToBestFit_horizontal_track_same_latitude() {
+        JXMapViewer mapViewer = new JXMapViewer();
+        mapViewer.setSize(100, 100);
+        GeoPosition position1 = new GeoPosition(50,  5, 0, 8, 41, 0);
+        GeoPosition position2 = new GeoPosition(50,  5, 0, 8, 14, 0);
+        List<GeoPosition> track = Arrays.asList(position1, position2);
+
+        mapViewer.zoomToBestFit(new HashSet<GeoPosition>(track), 0.7);
+    }
+
+    /**
+     *
+     * 21.10.2022: red: Method zoomToBestFit throws
+     * java.lang.IllegalArgumentException: GeoBounds is not valid - minLat must be less that maxLat.
+     */
+    @Test
+    public void zoomToBestFit_vertical_track_same_longitude() {
+        JXMapViewer mapViewer = new JXMapViewer();
+        mapViewer.setSize(100, 100);
+        GeoPosition position1 = new GeoPosition(50,  7, 0, 8, 41, 0);
+        GeoPosition position2 = new GeoPosition(50,  5, 0, 8, 41, 0);
+        List<GeoPosition> track = Arrays.asList(position1, position2);
+
+        mapViewer.zoomToBestFit(new HashSet<GeoPosition>(track), 0.7);
+    }
+}

--- a/jxmapviewer2/src/test/java/org/jxmapviewer/JXMapViewerTest.java
+++ b/jxmapviewer2/src/test/java/org/jxmapviewer/JXMapViewerTest.java
@@ -41,7 +41,8 @@ public class JXMapViewerTest {
     /**
      *
      * 21.10.2022: red: Method zoomToBestFit throws
-     * java.lang.IllegalArgumentException: GeoBounds is not valid - minLat must be less that maxLat.
+     * java.lang.IllegalArgumentException: GeoBounds is not valid - minLng must be less that maxLng or
+     * minLng must be greater than 0 and maxLng must be less than 0.
      */
     @Test
     public void zoomToBestFit_vertical_track_same_longitude() {

--- a/jxmapviewer2/src/test/java/org/jxmapviewer/awt/Rectangle2DTest.java
+++ b/jxmapviewer2/src/test/java/org/jxmapviewer/awt/Rectangle2DTest.java
@@ -1,0 +1,33 @@
+package org.jxmapviewer.awt;
+
+import org.junit.Test;
+import org.jxmapviewer.viewer.GeoBounds;
+
+import java.awt.geom.Rectangle2D;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Rectangle2DTest {
+
+    @Test
+    public void test_zero_width_and_zero_height_rect_do_not_intersect() {
+        Rectangle2D horizontalTrackRect = new Rectangle2D.Double(50.0, 7.9, 0, 0.2);
+        Rectangle2D verticalTrackRect = new Rectangle2D.Double(49.9, 8.0, 0.2, 0);
+        assertFalse(horizontalTrackRect.intersects(verticalTrackRect));
+    }
+
+    @Test
+    public void test_zero_height_rect_does_not_intersect() {
+        Rectangle2D horizontalTrackRect = new Rectangle2D.Double(50.0, 7.9, 0.00001, 0.2);
+        Rectangle2D verticalTrackRect = new Rectangle2D.Double(49.9, 8.0, 0.2, 0);
+        assertFalse(horizontalTrackRect.intersects(verticalTrackRect));
+    }
+
+    @Test
+    public void test_rectangles_intersect() {
+        Rectangle2D horizontalTrackRect = new Rectangle2D.Double(50.0, 7.9, 0.00001, 0.2);
+        Rectangle2D verticalTrackRect = new Rectangle2D.Double(49.9, 8.0, 0.2, 0.00001);
+        assertTrue(horizontalTrackRect.intersects(verticalTrackRect));
+    }
+}


### PR DESCRIPTION
allows GeoBounds to have height and/or width of zero. It is the same behavior as in the Java standard library java.awt.geom.Rectangle2D or in the Leaflet-JavaScript-Library latLngBounds) This change makes it possible for zoomToBestFit() to have 2 or more points as parameter which lie vertically or horizontally on a line / have same longitude or latitude.

I did some automatic tests with JUnit and I testet manually with my project https://github.com/Heiko-Zelt/wege-frei-pc (still under heavy construction). It works for me.