### PR TITLE
fix for transparent loading images

### DIFF
--- a/jxmapviewer2/src/main/java/org/jxmapviewer/JXMapViewer.java
+++ b/jxmapviewer2/src/main/java/org/jxmapviewer/JXMapViewer.java
@@ -265,8 +265,11 @@ public class JXMapViewer extends JPanel implements DesignMode
                         {
                             int imageX = (getTileFactory().getTileSize(zoom) - getLoadingImage().getWidth(null)) / 2;
                             int imageY = (getTileFactory().getTileSize(zoom) - getLoadingImage().getHeight(null)) / 2;
-                            g.setColor(Color.GRAY);
-                            g.fillRect(ox, oy, size, size);
+                            if (isOpaque())
+                            {
+                                g.setColor(getBackground);
+                                g.fillRect(ox, oy, size, size);
+                            }
                             g.drawImage(getLoadingImage(), ox + imageX, oy + imageY, null);
                         }
                     }


### PR DESCRIPTION
On an opaque JXMapViewer with transparent 'loading' image, a hardcoded background color is drawn.
With this fix the container backgroudcolor is drawn if the JXMapViewer is opaque, else only the loadingimage, in my usecase a transparent one.